### PR TITLE
Configurable robots.txt for Litapp Blog

### DIFF
--- a/plugins/litapp/blog/build.txt
+++ b/plugins/litapp/blog/build.txt
@@ -42,3 +42,8 @@ $:/plugins/litapp/blog/templates/rss
 static/sitemap.xml
 text/plain
 $:/plugins/litapp/blog/sitemap
+--render
+[[$:/plugins/litapp/blog/robots]]
+static/robots.txt
+text/plain
+$:/plugins/litapp/blog/robots

--- a/plugins/litapp/blog/config.tid
+++ b/plugins/litapp/blog/config.tid
@@ -10,6 +10,7 @@ type: text/vnd.tiddlywiki
 |$:/config/blog/SiteBaseUrl|<$edit-text tiddler="$:/config/blog/SiteBaseUrl" tag=input default="" />|{{$:/config/blog/SiteBaseUrl}}|
 |$:/config/blog/author|<$edit-text tiddler="$:/config/blog/author" tag=input default="" />|{{$:/config/blog/author}}|
 |$:/config/blog/environment|<$edit-text tiddler="$:/config/blog/environment" tag=input default="prod" />|{{$:/config/blog/environment}}|
+|$:/config/blog/robots.txt|<$edit-text tiddler="$:/config/blog/robots.txt" tag=textarea default="" />|{{$:/config/blog/robots.txt}}|
 |$:/config/blog/links|Edit as data tiddler: [[$:/config/blog/links]]|{{$:/config/blog/links}}|
 
 !! RSS Feed Settings

--- a/plugins/litapp/blog/robots.tid
+++ b/plugins/litapp/blog/robots.tid
@@ -1,0 +1,17 @@
+title: $:/plugins/litapp/blog/robots
+type: text/vnd.tiddlywiki
+
+\whitespace trim
+<$wikify name="siteUrl" text={{$:/config/blog/SiteBaseUrl}} output="text">
+<$vars siteUrl={{{ [<siteUrl>trim[]removesuffix[/]] }}}>
+<$list filter="[{$:/config/blog/robots.txt}!is[blank]]" variable="ignore">
+<$text text={{$:/config/blog/robots.txt}}/>
+</$list>
+<$list filter="[{$:/config/blog/robots.txt}is[blank]]" variable="ignore">
+User-agent: *
+Allow: /
+
+Sitemap: <$text text=<<siteUrl>>/>/sitemap.xml
+</$list>
+</$vars>
+</$wikify>

--- a/scripts/test-robots.js
+++ b/scripts/test-robots.js
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
+import test from "node:test";
+import assert from "node:assert";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.join(__dirname, "..");
+const robotsPath = path.join(
+  rootDir,
+  "editions",
+  "demo",
+  "output",
+  "static",
+  "robots.txt",
+);
+
+test("Robots.txt generation", async (t) => {
+  await t.test("Build blog", () => {
+    // Always build to ensure we are testing the latest changes
+    execSync("yarn build-blog", { stdio: "inherit", cwd: rootDir });
+  });
+
+  await t.test("Verify robots.txt existence and content", () => {
+    assert.strictEqual(fs.existsSync(robotsPath), true, "robots.txt does not exist");
+    const content = fs.readFileSync(robotsPath, "utf-8");
+    assert.notStrictEqual(content.length, 0, "robots.txt is empty");
+
+    assert.ok(content.includes("User-agent: *"), "Missing User-agent");
+    assert.ok(content.includes("Allow: /"), "Missing Allow: /");
+    assert.ok(content.includes("Sitemap:"), "Missing Sitemap keyword");
+    assert.ok(content.includes("/sitemap.xml"), "Missing /sitemap.xml");
+
+    // Ensure no TiddlyWiki artifacts like backticks or other formatting
+    assert.ok(!content.includes("`"), "Contains unexpected backticks");
+  });
+});


### PR DESCRIPTION
This change introduces a configurable `robots.txt` file for the Litapp Blog.

Key features:
- **Default robots.txt**: Generates a standard `robots.txt` that allows all crawlers and links to the `sitemap.xml` (using the configured `SiteBaseUrl`).
- **Customizable**: Users can override the default content by editing the `$:/config/blog/robots.txt` tiddler through the new editor in the "Blog Settings" configuration page.
- **Automated Generation**: The file is automatically rendered to `static/robots.txt` during the `yarn build-blog` process.
- **Verification**: A new test suite `scripts/test-robots.js` ensures that the file is correctly generated and free of TiddlyWiki formatting artifacts.
- **Improved Template Logic**: Refined the rendering template to use `<$text>` to prevent TiddlyWiki from interpreting standard robots.txt characters (like `*`) as formatting.

---
*PR created automatically by Jules for task [16147945716552763654](https://jules.google.com/task/16147945716552763654) started by @carlo-colombo*