### PR TITLE
Add PR comment with generated screenshots

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,11 +107,16 @@ jobs:
           path: screenshots/
       - name: Add Screenshots to Summary
         run: cat screenshots/summary.md >> $GITHUB_STEP_SUMMARY
-      - name: PR Comment Screenshots
+      - name: PR Comment Screenshots (Desktop)
         uses: mshick/add-pr-comment@v3
         with:
-          message-path: screenshots/summary.md
-          message-id: pr-screenshots
+          message-path: screenshots/summary-desktop.md
+          message-id: pr-screenshots-desktop
+      - name: PR Comment Screenshots (Mobile)
+        uses: mshick/add-pr-comment@v3
+        with:
+          message-path: screenshots/summary-mobile.md
+          message-id: pr-screenshots-mobile
 
   build:
     needs: test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,9 @@ jobs:
     needs: test
     name: PR Screenshots
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -104,6 +107,11 @@ jobs:
           path: screenshots/
       - name: Add Screenshots to Summary
         run: cat screenshots/summary.md >> $GITHUB_STEP_SUMMARY
+      - name: PR Comment Screenshots
+        uses: mshick/add-pr-comment@v3
+        with:
+          message-path: screenshots/summary.md
+          message-id: pr-screenshots
 
   build:
     needs: test

--- a/scripts/capture-screenshots.js
+++ b/scripts/capture-screenshots.js
@@ -71,12 +71,12 @@ const server = app.listen(9021, async () => {
     { name: "mobile", ...devices["iPhone 13"] },
   ];
 
-  let summaryMarkdown = "## PR Screenshots\n\n";
-  summaryMarkdown +=
-    "Full-page screenshots are attached as artifacts to this run.\n\n";
+  const summaries = {};
 
   for (const config of configs) {
-    summaryMarkdown += `### ${config.name.charAt(0).toUpperCase() + config.name.slice(1)}\n\n`;
+    let summaryMarkdown = `## PR Screenshots (${config.name.charAt(0).toUpperCase() + config.name.slice(1)})\n\n`;
+    summaryMarkdown +=
+      "Full-page screenshots are attached as artifacts to this run.\n\n";
     summaryMarkdown += "| Page | Preview |\n| --- | --- |\n";
 
     const context = await browser.newContext(config);
@@ -110,7 +110,7 @@ const server = app.listen(9021, async () => {
         await page.screenshot({
           path: thumbPath,
           type: "jpeg",
-          quality: 20,
+          quality: 10,
           fullPage: false,
         });
 
@@ -122,14 +122,21 @@ const server = app.listen(9021, async () => {
       }
     }
     await context.close();
-    summaryMarkdown += "\n";
+    summaries[config.name] = summaryMarkdown;
   }
 
   await browser.close();
   server.close();
 
-  fs.writeFileSync(path.join(screenshotsDir, "summary.md"), summaryMarkdown);
+  for (const [name, markdown] of Object.entries(summaries)) {
+    fs.writeFileSync(path.join(screenshotsDir, `summary-${name}.md`), markdown);
+  }
+
+  // Keep summary.md for GITHUB_STEP_SUMMARY, concatenating all summaries
+  const fullSummary = Object.values(summaries).join("\n\n");
+  fs.writeFileSync(path.join(screenshotsDir, "summary.md"), fullSummary);
+
   console.log(
-    `Screenshots captured successfully. Summary size: ${Math.round(summaryMarkdown.length / 1024)} KB`,
+    `Screenshots captured successfully. Total summary size: ${Math.round(fullSummary.length / 1024)} KB`,
   );
 });


### PR DESCRIPTION
This change adds an automated PR comment that displays the generated screenshots for each pull request. It uses the `mshick/add-pr-comment` action to post the contents of `screenshots/summary.md` (which includes base64-encoded thumbnails) as a sticky comment on the PR. Appropriate permissions have been added to the workflow to allow the action to post comments and access the repository content.

---
*PR created automatically by Jules for task [3447322810809361889](https://jules.google.com/task/3447322810809361889) started by @carlo-colombo*